### PR TITLE
Use actual query to get survey stats

### DIFF
--- a/src/call/actions/survey/index.tsx
+++ b/src/call/actions/survey/index.tsx
@@ -1,6 +1,7 @@
 import { request } from "graphql-request";
 import {
   GET_SURVEY,
+  GET_SURVEY_STATS,
   GET_SURVEYS,
   DELETE_SURVEY,
   ADD_SURVEY,
@@ -29,6 +30,16 @@ export const useGetSurvey = (id: string): UseQueryResult<ISurveyRes, Error> =>
     ["getSurvey", id],
     () =>
       request(API_URL, GET_SURVEY, {
+        id,
+      }),
+    { enabled: !!id }
+  );
+
+  export const useGetSurveyStats: any = (id: string) =>
+  useQuery(
+    ["getSurveyStats", id],
+    () =>
+      request(API_URL, GET_SURVEY_STATS, {
         id,
       }),
     { enabled: !!id }

--- a/src/call/queries/survey/index.ts
+++ b/src/call/queries/survey/index.ts
@@ -60,6 +60,25 @@ export const GET_SURVEY = gql`
   }
 `;
 
+export const GET_SURVEY_STATS = gql`
+  query getSurveyStats($id: ID!) {
+    surveyStats(id: $id) {
+      title
+      description
+      publishedAt
+      createdAt
+      statistics {
+        day { visits, consented, completed }
+        week { visits, consented, completed }
+        month { visits, consented, completed }
+        semester { visits, consented, completed }
+        year { visits, consented, completed }
+        all { visits, consented, completed }
+      }
+    }
+  }
+`;
+
 export const UPDATE_SURVEY = gql`
   mutation updateSurvey($id: ID!, $data: editSurveyInput) {
     updateSurvey(input: { where: { id: $id }, data: $data }) {


### PR DESCRIPTION
## What is this PR
This PR uses an actual query to display the survey stats and data in the side menu (in the Dashboard).

## How does it work
Simply add the necessary verbose to call the `surveyStats` query from the API, then use this data to display it in the UI.
We had to make a dirty check when it's loading (and display bare div) to make it work: this should definitely be improved.

## Test
- [ ] Just open your dashboard and play with the stats and filter => it actually comes from the API
(disclaimer: the visits are still fake because we don't have any analytics yet)