### PR TITLE
Improvement : Increase `TextArea` limits

### DIFF
--- a/src/api/actions/password/index.tsx
+++ b/src/api/actions/password/index.tsx
@@ -36,6 +36,7 @@ export const resetPassword: any = async (code: string, password: string, passwor
     password,
     passwordConfirmation,
   });
+
   if (res.status === 200) {
     return res;
   } else {

--- a/src/components/Fields/Textarea.tsx
+++ b/src/components/Fields/Textarea.tsx
@@ -57,7 +57,7 @@ export const CustomTextarea: React.FC<Props> = ({
               color: "#9E9E9E",
               fontSize: isBig ? "16px" : "12px",
             }}
-            overflow="hidden"
+            overflow="scroll-y"
             isDisabled={isDisabled}
             id={id}
             style={{ resize: "none" }}

--- a/src/components/Fields/utils/index.tsx
+++ b/src/components/Fields/utils/index.tsx
@@ -1,8 +1,6 @@
 import { Enum_Question_Rows, Maybe } from "api/graphql/types.generated";
 
-export const getRows = (
-  size: Maybe<Enum_Question_Rows> | undefined
-): number => {
+export const getRows = (size: Maybe<Enum_Question_Rows> | undefined): number => {
   switch (size) {
     case Enum_Question_Rows.Small:
       return 1;
@@ -20,22 +18,7 @@ export const getRows = (
   }
 };
 
-export const getMaxLength = (
-  size: Maybe<Enum_Question_Rows> | undefined
-): number => {
-  switch (size) {
-    case Enum_Question_Rows.Small:
-      return 50;
-      break;
-    case Enum_Question_Rows.Medium:
-      return 500;
-      break;
-    case Enum_Question_Rows.Large:
-      return 5000;
-      break;
-
-    default:
-      return 50;
-      break;
-  }
+export const getMaxLength = (_size: Maybe<Enum_Question_Rows> | undefined): number => {
+  // NOTE : Let's use a flat value for everything for now
+  return 7000;
 };


### PR DESCRIPTION
## What
This PR increases the limits of characters in the `TextArea` components, setting them all to an high value. The size difference is thus only visual (size of the field in the UI). It also adds the scroll bar when it is needed.

## How
Simply setting `maxLength` in `TextArea` to `7000`, whatever the selected size of the field is. The visual difference stays. It also changes `overflow` to `scroll-y`, so it shows the bar when needed.